### PR TITLE
Feature auto commit option

### DIFF
--- a/vs-commitizen.vs2015/VsCommitizenSection.cs
+++ b/vs-commitizen.vs2015/VsCommitizenSection.cs
@@ -29,11 +29,11 @@ namespace vs_commitizen.vs2015
             var teamExplorer = GetService<ITeamExplorer>();
             var page = teamExplorer.CurrentPage as TeamExplorerBasePage;
 
-            this.CommitizenSection.CommitExecuted += (s, ee) =>
+            this.CommitizenSection.ProceedExecuted += (s, autoCommit) =>
             {
                 AddNavigationValue(NavigationDataType.CommitData, new NavigationCommitModel
                 {
-                    AutoCommit = true, //TODO: add an option for this
+                    AutoCommit = autoCommit,
                     Comment = CommitizenSection.GetComment()
                 });
 

--- a/vs-commitizen.vs2015/VsCommitizenView.xaml
+++ b/vs-commitizen.vs2015/VsCommitizenView.xaml
@@ -15,23 +15,23 @@
                   Name="cbType"
                   DisplayMemberPath="DisplayString"
                   SelectedValuePath="Name" />
-        
+
         <Label Content="Scope :" HorizontalAlignment="Left" Margin="0,53,0,0" VerticalAlignment="Top"/>
         <Controls:TextBoxWithHint x:Name="tbxScope" HintText="Denote the scope of this change (optional)" 
                                   Height="24" Margin="0,79,25,0" VerticalAlignment="Top" 
                                   Text="{Binding ElementName=CtrlCommitizen, Path=Scope, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        
+
         <Label Content="Subject :" HorizontalAlignment="Left" Margin="0,108,0,0" VerticalAlignment="Top" />
         <Controls:TextBoxWithHint x:Name="tbxSubject" HintText="Write a short, imperative tense description of the change" 
                                   Height="24" Margin="0,134,25,0" VerticalAlignment="Top"
                                   Text="{Binding ElementName=CtrlCommitizen, Path=Subject, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        
+
         <Label Content="Body :" HorizontalAlignment="Left" Margin="0,163,0,0" VerticalAlignment="Top"/>
         <Controls:TextBoxWithHint x:Name="tbxBody" HintText="Provide a longer description of the change (optional)" 
                                   Height="75" Margin="0,189,25,0" VerticalAlignment="Top"
                                   AcceptReturn="true"
                                   Text="{Binding ElementName=CtrlCommitizen, Path=Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-        
+
         <Label Content="Breaking changes :" HorizontalAlignment="Left" Margin="0,269,0,0" VerticalAlignment="Top"/>
         <Controls:TextBoxWithHint x:Name="tbxBreakingChanges" HintText="List any breaking changes (optional)" 
                                   Height="24" Margin="0,295,25,0" VerticalAlignment="Top"
@@ -41,9 +41,14 @@
         <Controls:TextBoxWithHint x:Name="tbxIssuesAffected" HintText="List any issues affected by this change (optional). E.g.: 'fix #123', 're #123'" 
                                   Height="24" Margin="0,350,25,0" VerticalAlignment="Top"
                                   Text="{Binding ElementName=CtrlCommitizen, Path=IssuesAffected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-        
-        <Button Name="BtnCommit" Content="Commit" 
-                HorizontalAlignment="Left" Margin="0,386,0,0" VerticalAlignment="Top" Width="75" 
-                Command="{Binding ElementName=CtrlCommitizen, Path=OnCommit}" />
+
+        <Button Name="btnCommit" Content="Commit" 
+                HorizontalAlignment="Left" Margin="114,386,0,0" VerticalAlignment="Top" Width="74" 
+                Command="{Binding ElementName=CtrlCommitizen, Path=OnProceed}" CommandParameter="true"
+                ToolTip="Proceed to 'Changes' view and commit" />
+        <Button x:Name="btnProceed" Content="Proceed" 
+            HorizontalAlignment="Left" Margin="0,386,0,0" VerticalAlignment="Top" Width="76" 
+            Command="{Binding ElementName=CtrlCommitizen, Path=OnProceed}" CommandParameter="false"
+            ToolTip="Proceed to 'Changes' view" />
     </Grid>
 </UserControl>

--- a/vs-commitizen.vs2015/VsCommitizenView.xaml.cs
+++ b/vs-commitizen.vs2015/VsCommitizenView.xaml.cs
@@ -18,6 +18,7 @@ namespace vs_commitizen.vs
     /// </summary>
     public partial class VsCommitizenView : UserControl, INotifyPropertyChanged, ICommentBuilder
     {
+        #region Bound properties
         private List<CommitType> _commitTypes;
         public List<CommitType> CommitTypes
         {
@@ -81,7 +82,7 @@ namespace vs_commitizen.vs
             {
                 _subject = value;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(OnCommit));
+                OnPropertyChanged(nameof(OnProceed));
             }
         }
 
@@ -93,9 +94,10 @@ namespace vs_commitizen.vs
             {
                 _hasGitPendingChanges = value;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(OnCommit));
+                OnPropertyChanged(nameof(OnProceed));
             }
         }
+        #endregion
 
         public VsCommitizenView()
         {
@@ -115,7 +117,7 @@ namespace vs_commitizen.vs
                 new CommitType("chore", "Other changes that don't modify src or test files"),
                 new CommitType("revert", "Reverts a previous commit")
             };
-            this.OnCommit = new RelayCommand(Commit, CanCommit);
+            this.OnProceed = new RelayCommand(Proceed, CanProceed);
             this.HasGitPendingChanges = true;   //TODO: Correct way to bind this
 
             this.DataContext = this;
@@ -127,7 +129,7 @@ namespace vs_commitizen.vs
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public bool CanCommit(object param)
+        public bool CanProceed(object param)
         {
             if (this.cbType.SelectedIndex < 0) return false;
             if (string.IsNullOrWhiteSpace(this.tbxSubject.Text)) return false;
@@ -136,9 +138,10 @@ namespace vs_commitizen.vs
             return true;
         }
 
-        public void Commit(object param)
+        public void Proceed(object param)
         {
-            CommitExecuted?.Invoke(this, new EventArgs());
+            var doCommit = param is bool && (bool)param;
+            ProceedExecuted?.Invoke(this, doCommit);
         }
 
         public string GetComment()
@@ -167,15 +170,15 @@ namespace vs_commitizen.vs
             return comment;
         }
 
-        public event EventHandler CommitExecuted;
+        public event EventHandler<bool> ProceedExecuted;
 
-        private ICommand _onCommit;
-        public ICommand OnCommit
+        private ICommand _onProceed;
+        public ICommand OnProceed
         {
-            get => _onCommit;
+            get => _onProceed;
             set
             {
-                _onCommit = value;
+                _onProceed = value;
                 OnPropertyChanged();
             }
         }

--- a/vs-commitizen/vs-commitizen.csproj
+++ b/vs-commitizen/vs-commitizen.csproj
@@ -144,9 +144,7 @@
   </Target>
   -->
   <Import Project="..\.paket\paket.targets" />
-  <ItemGroup>
-    <Folder Include="GUI\" />
-  </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.1'">
       <ItemGroup>


### PR DESCRIPTION
Add a "Proceed" button in commitizen view so you can either :
- commit => directly commit your changes with generated comment
- proceed => fill comment in 'Changes' view and manually proceed with different Commit options