### PR TITLE
fix: Quick settings access in vs2017

### DIFF
--- a/vs-commitizen.Settings/Bootstrap.cs
+++ b/vs-commitizen.Settings/Bootstrap.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace vs_commitizen.Settings
 {
@@ -9,7 +10,7 @@ namespace vs_commitizen.Settings
             IoC.Container.Configure(c =>
             {
                 c.AddRegistry<ExtensionRegistry>();
-                c.ForSingletonOf<Package>().Use(package);
+                c.ForSingletonOf<IVsPackage>().Use(package);
             });
         }
     }

--- a/vs-commitizen.vs2015/VsCommitizenSection.cs
+++ b/vs-commitizen.vs2015/VsCommitizenSection.cs
@@ -3,7 +3,10 @@ using Microsoft.TeamFoundation.Controls.WPF;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using Microsoft.TeamFoundation.MVVM;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using System.ComponentModel;
+using System.Reflection;
 using System.Windows.Media;
 using vs_commitizen.Settings;
 using vs_commitizen.vs;
@@ -33,8 +36,9 @@ namespace vs_commitizen.vs2015
 
         private void ExecuteOpenSettings()
         {
-            var package = IoC.GetInstance<Package>();
-            package.ShowOptionPage(typeof(SettingsGeneral));
+            var package = IoC.GetInstance<IVsPackage>();
+            var showOptionPageMethod = package.GetType().GetMethod("ShowOptionPage", BindingFlags.Public | BindingFlags.Instance);
+            showOptionPageMethod.Invoke(package, new[] { typeof(SettingsGeneral) });
         }
 
         public override void Initialize(object sender, SectionInitializeEventArgs e)


### PR DESCRIPTION
IoC resolution was wrong since between registration and usage, a different version of Package was
used and was never resolved