### PR TITLE
Fix init config

### DIFF
--- a/vs-commitizen.Tests/OpenGenerateLocalConfigViewModelTests.cs
+++ b/vs-commitizen.Tests/OpenGenerateLocalConfigViewModelTests.cs
@@ -1,0 +1,132 @@
+﻿using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Shouldly;
+using System.Threading.Tasks;
+using vs_commitizen.Infrastructure;
+using vs_commitizen.Settings;
+using vs_commitizen.Tests.TestAttributes;
+using vs_commitizen.ViewModels;
+using Xunit;
+
+namespace vs_commitizen.Tests
+{
+    public class OpenGenerateLocalConfigViewModelTests
+    {
+        OpenGenerateLocalConfigViewModel getSut(Fixture fixture, ConfigFileProvider configFileProvider, IFileAccessor fileAccessor, string configPath, bool fileExists)
+        {
+            configFileProvider.Configure().TryGetLocalConfigAsync().Returns(configPath);
+            fileAccessor.Exists(Arg.Any<string>()).ReturnsForAnyArgs(fileExists);
+
+            IoC.Container.Inject<IConfigFileProvider>(configFileProvider);
+            IoC.Container.Inject<IFileAccessor>(fileAccessor);
+            return fixture.Create<OpenGenerateLocalConfigViewModel>();
+        }
+
+        [Theory]
+        [InlineTestConventions(true, "path to config")]
+        [InlineTestConventions(false, null)]
+        public async Task Command_Is_Enabled_Based_On_Solution_Loaded(
+            bool solutionLoaded,
+            string configPath,
+            [Frozen]IFileAccessor fileAccessor,
+            [Frozen][Substitute] ConfigFileProvider configFileProvider,
+            Fixture fixture
+            )
+        {
+            var sut = getSut(fixture, configFileProvider, fileAccessor, configPath, solutionLoaded);
+
+            var expectedEnabledState = solutionLoaded;
+            (await sut.IsCommandEnabledAsync()).ShouldBe(expectedEnabledState);
+        }
+
+        [Theory]
+        [InlineTestConventions(true, "path to config")]
+        public async Task Execute_With_Existing_Config_Opens_The_File(
+            bool solutionLoaded,
+            string configPath,
+            [Frozen]IFileAccessor fileAccessor,
+            [Frozen][Substitute] IPopupManager popupManager,
+            [Frozen][Substitute] ConfigFileProvider configFileProvider,
+            Fixture fixture
+            )
+        {
+            // Arrange
+            var sut = getSut(fixture, configFileProvider, fileAccessor, configPath, solutionLoaded);
+            var called = false;
+
+            // Act
+            await sut.ExecuteAsync(s =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            });
+
+            // Assert
+            called.ShouldBeTrue();
+            popupManager.DidNotReceiveWithAnyArgs().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Theory]
+        [InlineTestConventions(false, "path to config")]
+        public async Task Execute_With_NonExisting_Config_Asks_To_Create_It(
+            bool solutionLoaded,
+            string configPath,
+            [Frozen]IFileAccessor fileAccessor,
+            [Frozen][Substitute] IPopupManager popupManager,
+            [Frozen][Substitute] ConfigFileProvider configFileProvider,
+            Fixture fixture
+            )
+        {
+            // Arrange
+            IoC.Container.Inject(popupManager);
+            var sut = getSut(fixture, configFileProvider, fileAccessor, configPath, solutionLoaded);
+            var called = false;
+
+            // Act
+            await sut.ExecuteAsync(s =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            });
+
+            // Assert
+            called.ShouldBeFalse();
+            popupManager.Received().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Theory]
+        [InlineTestConventions(false, "path to config", true)]
+        [InlineTestConventions(false, "path to config", false)]
+        public async Task Response_To_Popup_Should_Open_File(
+            bool solutionLoaded,
+            string configPath,
+            bool userWantsToCreateFile,
+            [Frozen]IFileAccessor fileAccessor,
+            [Frozen][Substitute] IPopupManager popupManager,
+            [Frozen][Substitute] ConfigFileProvider configFileProvider,
+            Fixture fixture
+            )
+        {
+            // Arrange
+            popupManager.Configure().Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(userWantsToCreateFile);
+            IoC.Container.Inject(popupManager);
+            var sut = getSut(fixture, configFileProvider, fileAccessor, configPath, solutionLoaded);
+            var called = false;
+
+            // Act
+            await sut.ExecuteAsync(s =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            });
+
+            // Assert
+            var expectedResult = userWantsToCreateFile;
+            called.ShouldBe(expectedResult);
+            popupManager.Received().Confirm(Arg.Any<string>(), Arg.Any<string>());
+        }
+    }
+}

--- a/vs-commitizen.Tests/OpenGenerateLocalConfigViewModelTests.cs
+++ b/vs-commitizen.Tests/OpenGenerateLocalConfigViewModelTests.cs
@@ -20,8 +20,12 @@ namespace vs_commitizen.Tests
             configFileProvider.Configure().TryGetLocalConfigAsync().Returns(configPath);
             fileAccessor.Exists(Arg.Any<string>()).ReturnsForAnyArgs(fileExists);
 
+            IoC.Container.EjectAllInstancesOf<IConfigFileProvider>();
             IoC.Container.Inject<IConfigFileProvider>(configFileProvider);
+
+            IoC.Container.EjectAllInstancesOf<IFileAccessor>();
             IoC.Container.Inject<IFileAccessor>(fileAccessor);
+
             return fixture.Create<OpenGenerateLocalConfigViewModel>();
         }
 

--- a/vs-commitizen.Tests/vs-commitizen.Tests.csproj
+++ b/vs-commitizen.Tests/vs-commitizen.Tests.csproj
@@ -56,6 +56,9 @@
     <Reference Include="Microsoft.TeamFoundation.Controls">
       <HintPath>..\lib\vs2019\Microsoft.TeamFoundation.Controls.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.TeamFoundation.Git.Provider">
+      <HintPath>..\lib\vs2019\Microsoft.TeamFoundation.Git.Provider.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -73,6 +76,7 @@
     <Compile Include="TestAttributes\TestConventionsAttribute.cs" />
     <Compile Include="CommitizenViewModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="OpenGenerateLocalConfigViewModelTests.cs" />
     <Compile Include="ViewTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/vs-commitizen/Infrastructure/ConfigFileProvider.cs
+++ b/vs-commitizen/Infrastructure/ConfigFileProvider.cs
@@ -107,7 +107,7 @@ namespace vs_commitizen.Infrastructure
             return (repository != null, repository?.RepositoryPath);
         }
 
-        public async Task<string> TryGetLocalConfigAsync()
+        public virtual async Task<string> TryGetLocalConfigAsync()
         {
             var (isRepositoryLoaded, repositoryPath) = await GetLocalPathAsync(); // await GetCurrentSolutionAsync();
             if (isRepositoryLoaded)

--- a/vs-commitizen/Infrastructure/ConfigFileProvider.cs
+++ b/vs-commitizen/Infrastructure/ConfigFileProvider.cs
@@ -181,7 +181,7 @@ namespace vs_commitizen.Infrastructure
                     var defaultConfigFileContent = await reader.ReadToEndAsync();
                     await fileStream.WriteAsync(defaultConfigFileContent);
 
-                    return defaultConfigFileContent;
+                    return JObject.Parse(defaultConfigFileContent).SelectToken("types").ToString();
                 }
             }
         }

--- a/vs-commitizen/ViewModels/OpenGenerateLocalConfigViewModel.cs
+++ b/vs-commitizen/ViewModels/OpenGenerateLocalConfigViewModel.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using vs_commitizen.Infrastructure;
+using vs_commitizen.Settings;
+
+namespace vs_commitizen.ViewModels
+{
+    public class OpenGenerateLocalConfigViewModel
+    {
+        private readonly IConfigFileProvider configFileProvider;
+        private readonly IFileAccessor fileAccessor;
+        private readonly IPopupManager popupManager;
+
+        public OpenGenerateLocalConfigViewModel()
+        {
+            configFileProvider = IoC.GetInstance<IConfigFileProvider>();
+            fileAccessor = IoC.GetInstance<IFileAccessor>();
+            popupManager = IoC.GetInstance<IPopupManager>();
+
+        }
+
+        public async Task<bool> IsCommandEnabledAsync()
+        {
+            var localConfigPath = await this.configFileProvider.TryGetLocalConfigAsync();
+
+            return !string.IsNullOrWhiteSpace(localConfigPath);
+        }
+
+        public async Task ExecuteAsync(Func<string, Task> openFunc)
+        {
+            try
+            {
+                var localConfigPath = await this.configFileProvider.TryGetLocalConfigAsync();
+                if (string.IsNullOrWhiteSpace(localConfigPath)) return;
+
+                if (fileAccessor.Exists(localConfigPath))
+                {
+                    await openFunc(localConfigPath);
+                }
+                else
+                {
+                    if (popupManager.Confirm("There is no local configuration file yet, do you want to create it for this repository ?", "Init local config file"))
+                    {
+                        fileAccessor.CopyFile(ConfigFileProvider.ConfigPathUserProfile, localConfigPath);
+                        await openFunc(localConfigPath);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                popupManager.Show(ex.ToString(), "An error occured");
+            }
+        }
+    }
+}

--- a/vs-commitizen/defaultConfigFile.json
+++ b/vs-commitizen/defaultConfigFile.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://github.com/MrLuje/vs-commitizen/config-schema.json",
+  "$schema": "https://raw.githubusercontent.com/MrLuje/vs-commitizen/master/config-schema.json",
   "types": [
     {
       "type": "feat",

--- a/vs-commitizen/vs-commitizen.csproj
+++ b/vs-commitizen/vs-commitizen.csproj
@@ -64,6 +64,7 @@
     <Compile Include="PackageRegistry.cs" />
     <Compile Include="Infrastructure\PopupManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ViewModels\OpenGenerateLocalConfigViewModel.cs" />
     <Compile Include="VsCommitizenIds.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
First config initialization were not returning the same schema as classic usage
Fix opening local configuration when user doesn't want to generate it